### PR TITLE
Add Waitable features to StateMachine, which fixes #14

### DIFF
--- a/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/StateMachine.java
+++ b/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/StateMachine.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
  *
  * @param <T> the user define state type
  */
-public interface StateMachine<T> {
+public interface StateMachine<T> extends WaitableSupplier<T> {
     
     /**
      * Set the current state, state must already exist and be an allowed transition
@@ -28,7 +28,9 @@ public interface StateMachine<T> {
      *
      * @return the current state, never null
      */
-    T getState();
+    default T getState() {
+        return get();
+    }
     
     /**
      * Determine if the given state is known

--- a/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/Waitable.java
+++ b/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/Waitable.java
@@ -2,9 +2,7 @@ package io.github.jonloucks.concurrency.api;
 
 import java.time.Duration;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * Provides mutable reference that allows other threads to wait until
@@ -12,51 +10,21 @@ import java.util.function.Supplier;
  *
  * @param <T> the type of references
  */
-public interface Waitable<T> extends Supplier<T>, Consumer<T> {
-    
+public interface Waitable<T> extends WaitableSupplier<T>, WaitableConsumer<T> {
+
     /**
-     * @return Get current value
-     */
-    @Override
-    T get();
-    
-    /**
-     * Gets the current value if it matches the current value
-     *
-     * @param predicate the predicate
-     * @return optionally get the current value if it matches
-     * @throws IllegalArgumentException if predicate is null or if value is null
-     */
-    Optional<T> getIf(Predicate<T> predicate);
-    
-    /**
-     * Assign a new value
-     *
-     * @param value the new value
-     *  @throws IllegalArgumentException if value is null
-     */
-    @Override
-    void accept(T value);
-    
-    /**
-     * Assign a new value if conditions are satisfied
-     *
-     * @param predicate the predicate to test if a value should be replaced
-     * @param value the new value
-     * @return if accepted the value replaced.
-     * @throws IllegalArgumentException if predicate is null or if value is null
-     */
-    Optional<T> acceptIf(Predicate<T> predicate, T value);
-    
-    /**
-     * Waits forever for a value to match the predicate
+     * Waits until condition is satisfied for a value to match the predicate
      *
      * @param predicate the predicate to test if the value satisfies the stop waiting condition
      * @return optionally the value if
      * @throws IllegalArgumentException if predicate is null
+     * @deprecated Replaced by {@link #getWhen(Predicate)}
      */
-    Optional<T> waitFor(Predicate<T> predicate);
-    
+    @Deprecated
+    default Optional<T> waitFor(Predicate<T> predicate) {
+        return getWhen(predicate);
+    }
+
     /**
      * Waits for given timeout for a value to match the predicate
      *
@@ -64,8 +32,12 @@ public interface Waitable<T> extends Supplier<T>, Consumer<T> {
      * @param timeout the time to wait for the value to satisfy the predicate
      * @return optionally the value if
      * @throws IllegalArgumentException if predicate is null, duration is null, or duration is negative
+     * @deprecated Replaced by {@link #getWhen(Predicate, Duration)}
      */
-    Optional<T> waitFor(Predicate<T> predicate, Duration timeout);
+    @Deprecated 
+    default Optional<T> waitFor(Predicate<T> predicate, Duration timeout) {
+        return getWhen(predicate, timeout);
+    }
     
     /**
      * Aborts all waiting threads.

--- a/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/WaitableConsumer.java
+++ b/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/WaitableConsumer.java
@@ -1,0 +1,30 @@
+package io.github.jonloucks.concurrency.api;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Waitable consumer
+ * @param <T> the type of value
+ */
+public interface WaitableConsumer<T> extends Consumer<T> {
+    /**
+     * Assign a new value
+     *
+     * @param value the new value
+     *  @throws IllegalArgumentException if value is null
+     */
+    @Override
+    void accept(T value);
+    
+    /**
+     * Assign a new value if conditions are satisfied
+     *
+     * @param predicate the predicate to test if a value should be replaced
+     * @param value the new value
+     * @return if accepted the value replaced.
+     * @throws IllegalArgumentException if predicate is null or if value is null
+     */
+    Optional<T> acceptIf(Predicate<T> predicate, T value);
+}

--- a/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/WaitableSupplier.java
+++ b/concurrency-api/src/main/java/io/github/jonloucks/concurrency/api/WaitableSupplier.java
@@ -1,0 +1,47 @@
+package io.github.jonloucks.concurrency.api;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Waitable supplier
+ * @param <T> the type of value supplied
+ */
+public interface WaitableSupplier<T> extends Supplier<T> {
+    
+    /**
+     * @return Get current value
+     */
+    @Override
+    T get();
+    
+    /**
+     * Gets the current value if it satisfies a condition
+     *
+     * @param predicate the predicate
+     * @return the current value iif the condition is satisfied
+     * @throws IllegalArgumentException if predicate is null or if value is null
+     */
+    Optional<T> getIf(Predicate<T> predicate);
+    
+    /**
+     * Waits until the current value if it satisfies a condition
+     *
+     * @param predicate the predicate to test if the value satisfies the stop waiting condition
+     * @return the current value iif the condition is satisfied
+     * @throws IllegalArgumentException if predicate is null
+     */
+    Optional<T> getWhen(Predicate<T> predicate);
+    
+    /**
+     * Waits until the current value if it satisfies a condition or a timeout is reached
+     *
+     * @param predicate the predicate to test if the value satisfies the stop waiting condition
+     * @param timeout the time to wait for the value to satisfy the predicate
+     * @return the current value iif the condition is satisfied
+     * @throws IllegalArgumentException if predicate is null, duration is null, or duration is negative
+     */
+    Optional<T> getWhen(Predicate<T> predicate, Duration timeout);
+}

--- a/concurrency-impl/src/main/java/io/github/jonloucks/concurrency/impl/Internal.java
+++ b/concurrency-impl/src/main/java/io/github/jonloucks/concurrency/impl/Internal.java
@@ -43,7 +43,7 @@ final class Internal {
         return illegalCheck(validTimeout, validTimeout.isNegative(), "Timeout must not be negative.");
     }
     
-    static void throwUnchecked(Throwable thrown, String message) throws Error, ConcurrencyException, RuntimeException {
+    static void throwUnchecked(Throwable thrown, String message) throws Error,  RuntimeException {
         if (null == thrown) {
             return;
         } else if (thrown instanceof Error) {
@@ -62,9 +62,7 @@ final class Internal {
     }
     
     private static void validateUnchecked(Throwable thrown, String message) throws Error, ConcurrencyException {
-        runWithIgnore( () -> {
-            throwUnchecked(thrown, message);
-        });
+        runWithIgnore( () -> throwUnchecked(thrown, message));
     }
     
     @FunctionalInterface

--- a/concurrency-impl/src/main/java/io/github/jonloucks/concurrency/impl/StateMachineImpl.java
+++ b/concurrency-impl/src/main/java/io/github/jonloucks/concurrency/impl/StateMachineImpl.java
@@ -4,8 +4,10 @@ import io.github.jonloucks.concurrency.api.ConcurrencyException;
 import io.github.jonloucks.concurrency.api.StateMachine;
 import io.github.jonloucks.concurrency.api.Waitable;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static io.github.jonloucks.concurrency.impl.Internal.*;
@@ -24,8 +26,23 @@ final class StateMachineImpl<S> implements StateMachine<S> {
     }
     
     @Override
-    public S getState() {
+    public S get() {
         return currentState.get();
+    }
+    
+    @Override
+    public Optional<S> getIf(Predicate<S> predicate) {
+        return currentState.getIf(predicate);
+    }
+    
+    @Override
+    public Optional<S> getWhen(Predicate<S> predicate) {
+        return currentState.getWhen(predicate);
+    }
+    
+    @Override
+    public Optional<S> getWhen(Predicate<S> predicate, Duration timeout) {
+        return currentState.getWhen(predicate, timeout);
     }
     
     @Override

--- a/concurrency-test/src/main/java/io/github/jonloucks/concurrency/test/ConcurrencyTests.java
+++ b/concurrency-test/src/main/java/io/github/jonloucks/concurrency/test/ConcurrencyTests.java
@@ -13,8 +13,7 @@ import java.util.function.Consumer;
 import static io.github.jonloucks.concurrency.test.Tools.withConcurrency;
 import static io.github.jonloucks.contracts.test.Tools.assertObject;
 import static io.github.jonloucks.contracts.test.Tools.assertThrown;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("CodeBlock2Expr")
 @ExtendWith(MockitoExtension.class)
@@ -60,9 +59,15 @@ public interface ConcurrencyTests {
     @Test
     default void concurrency_createStateMachine_WithValidInitial_Works() {
         withConcurrency((contracts, concurrency) -> {
-            final StateMachine<String> stateMachine = concurrency.createStateMachine("hello");
+            final String initialState = "initialState";
+            final StateMachine<String> stateMachine = concurrency.createStateMachine(initialState);
             assertObject(stateMachine);
-            assertEquals("hello", stateMachine.getState());
+            assertEquals(initialState, stateMachine.getState());
+            assertEquals(initialState, stateMachine.get());
+            assertTrue(stateMachine.getIf(initialState::equals).isPresent());
+            assertEquals(initialState, stateMachine.getIf(initialState::equals).get());
+            assertTrue(stateMachine.getWhen(initialState::equals).isPresent());
+            assertEquals(initialState, stateMachine.getWhen(initialState::equals).get());
         });
     }
     

--- a/concurrency-test/src/main/java/io/github/jonloucks/concurrency/test/WaitableTests.java
+++ b/concurrency-test/src/main/java/io/github/jonloucks/concurrency/test/WaitableTests.java
@@ -86,11 +86,11 @@ public interface WaitableTests {
     }
     
     @Test
-    default void waitable_waitFor_WithNullPredicate_Throws() {
+    default void waitable_getWhen_WithNullPredicate_Throws() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-                waitable.waitFor(null);
+                waitable.getWhen(null);
             });
             
             assertThrown(thrown, "Predicate must be present.");
@@ -98,12 +98,12 @@ public interface WaitableTests {
     }
     
     @Test
-    default void waitable_waitFor_WithNullPredicateAndTimeout_Throws() {
+    default void waitable_getWhen_WithNullPredicateAndTimeout_Throws() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final Duration timeout = Duration.ofSeconds(1);
             final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-                waitable.waitFor(null, timeout);
+                waitable.getWhen(null, timeout);
             });
             
             assertThrown(thrown, "Predicate must be present.");
@@ -111,12 +111,12 @@ public interface WaitableTests {
     }
     
     @Test
-    default void waitable_waitFor_WithPredicateAndNullTimeout_Throws() {
+    default void waitable_getWhen_WithPredicateAndNullTimeout_Throws() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final Predicate<String> predicate = s -> true;
             final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-                waitable.waitFor(predicate, null);
+                waitable.getWhen(predicate, null);
             });
             
             assertThrown(thrown, "Timeout must be present.");
@@ -124,13 +124,13 @@ public interface WaitableTests {
     }
     
     @Test
-    default void waitable_waitFor_WithPredicateAndNegativeTimeout_Throws() {
+    default void waitable_getWhen_WithPredicateAndNegativeTimeout_Throws() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final Predicate<String> predicate = s -> true;
             final Duration timeout = Duration.ofSeconds(-1);
             final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-                waitable.waitFor(predicate, timeout);
+                waitable.getWhen(predicate, timeout);
             });
             
             assertThrown(thrown, "Timeout must not be negative.");
@@ -138,6 +138,19 @@ public interface WaitableTests {
     }
     
     @Test
+    default void waitable_getWhen_WithInitialValue_Works() {
+        withConcurrency((contracts,concurrency)-> {
+            final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
+            
+            final Optional<String> optionalValue = waitable.getWhen(INITIAL::equals);
+            
+            assertTrue(optionalValue.isPresent());
+            assertEquals(INITIAL, optionalValue.get());
+        });
+    }
+    
+    @Test
+    @Deprecated
     default void waitable_waitFor_WithInitialValue_Works() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
@@ -161,6 +174,19 @@ public interface WaitableTests {
     }
     
     @Test
+    default void waitable_getWhen_WithInitialValueAndTimeout_Works() {
+        withConcurrency((contracts,concurrency)-> {
+            final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
+            
+            final Optional<String> optionalValue = waitable.getWhen(INITIAL::equals, Duration.ofDays(1));
+            
+            assertTrue(optionalValue.isPresent());
+            assertEquals(INITIAL, optionalValue.get());
+        });
+    }
+    
+    @Test
+    @Deprecated
     default void waitable_waitFor_WithInitialValueAndTimeout_Works() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
@@ -173,7 +199,7 @@ public interface WaitableTests {
     }
     
     @Test
-    default void waitable_waitFor_WithFailedAndTimeout_Works() {
+    default void waitable_getWhen_WithFailedAndTimeout_Works() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             
@@ -184,28 +210,28 @@ public interface WaitableTests {
             });
             thread.start();
             
-            final Optional<String> optionalValue = waitable.waitFor(MODIFIED::equals, Duration.ofMillis(100));
+            final Optional<String> optionalValue = waitable.getWhen(MODIFIED::equals, Duration.ofMillis(100));
             assertFalse(optionalValue.isPresent());
         });
     }
     
     @Test
-    default void waitable_waitFor_WithFailedAndZeroTimeout_Works() {
+    default void waitable_getWhen_WithFailedAndZeroTimeout_Works() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             
-            final Optional<String> optionalValue = waitable.waitFor(MODIFIED::equals, Duration.ZERO);
+            final Optional<String> optionalValue = waitable.getWhen(MODIFIED::equals, Duration.ZERO);
             assertFalse(optionalValue.isPresent());
             assertEquals(INITIAL, waitable.get());
         });
     }
     
     @Test
-    default void waitable_waitFor_WithFailedWhenShutdown_Works() {
+    default void waitable_getWhen_WithFailedWhenShutdown_Works() {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             waitable.shutdown();
-            final Optional<String> optionalValue = waitable.waitFor(MODIFIED::equals, Duration.ofMinutes(5));
+            final Optional<String> optionalValue = waitable.getWhen(MODIFIED::equals, Duration.ofMinutes(5));
             assertFalse(optionalValue.isPresent());
             assertEquals(INITIAL, waitable.get());
         });
@@ -213,7 +239,7 @@ public interface WaitableTests {
     
     @ParameterizedTest(name = "threads = {0}")
     @ValueSource(ints = {1,3,17})
-    default void waitable_waitFor_Threads_Works(int numberOfThreads) {
+    default void waitable_getWhen_Threads_Works(int numberOfThreads) {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
@@ -222,7 +248,7 @@ public interface WaitableTests {
             for (int i = 0; i < numberOfThreads; i++) {
                 final Thread thread = new Thread(() -> {
                     try {
-                        final Optional<String> optionalValue = waitable.waitFor(MODIFIED::equals, Duration.ofMinutes(5));
+                        final Optional<String> optionalValue = waitable.getWhen(MODIFIED::equals, Duration.ofMinutes(5));
                         if (optionalValue.isPresent()) {
                             countDownLatch.countDown();
                         } else {
@@ -248,7 +274,7 @@ public interface WaitableTests {
 
     @ParameterizedTest(name = "threads = {0}")
     @ValueSource(ints = {1,3,17})
-    default void waitable_waitFor_shutdownWithThreads_Works(int numberOfThreads) {
+    default void waitable_getWhen_shutdownWithThreads_Works(int numberOfThreads) {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
@@ -257,7 +283,7 @@ public interface WaitableTests {
             for (int i = 0; i < numberOfThreads; i++) {
                 final Thread thread = new Thread(() -> {
                     try {
-                        final Optional<String> optionalValue = waitable.waitFor(MODIFIED::equals, Duration.ofMinutes(5));
+                        final Optional<String> optionalValue = waitable.getWhen(MODIFIED::equals, Duration.ofMinutes(5));
                         if (!optionalValue.isPresent()) {
                             countDownLatch.countDown();
                         } else {
@@ -282,7 +308,7 @@ public interface WaitableTests {
     
     @ParameterizedTest(name = "threads = {0}")
     @ValueSource(ints = {1,3,17})
-    default void waitable_waitFor_WithThreadsAndTimeout_Works(int numberOfThreads) {
+    default void waitable_getWhen_WithThreadsAndTimeout_Works(int numberOfThreads) {
         withConcurrency((contracts,concurrency)-> {
             final Waitable<String> waitable = concurrency.createWaitable(INITIAL);
             final CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
@@ -291,7 +317,7 @@ public interface WaitableTests {
             for (int i = 0; i < numberOfThreads; i++) {
                 final Thread thread = new Thread(() -> {
                     try {
-                        final Optional<String> optionalValue = waitable.waitFor(MODIFIED::equals, Duration.ofMillis(25));
+                        final Optional<String> optionalValue = waitable.getWhen(MODIFIED::equals, Duration.ofMillis(25));
                         if (!optionalValue.isPresent()) {
                             countDownLatch.countDown();
                         } else {


### PR DESCRIPTION
# Feature: Add Waitable features to StateMachine, which fixes #14 

## Description

Request the ability to wait for a state change in the StateMachine

- Split out methods in Waitable into WaitableConsumer and WaitableSupplier
- StateMachine now extends WaitableSupplier without exposing mutable functions Waitable.
- Deprecated 'waitFor' and added replacement 'getWhen' which is a better name for the WaitableConsumer interface.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [ ] Chore (e.g., dependency updates, build tooling changes)

## How Has This Been Tested?

[Describe the testing you have performed to ensure the changes work as expected. Include details about:
Tests updated and pass

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes

